### PR TITLE
이혜진 - feat: 같은 수락창에 동일한 유저가 두명이 되지 않도록 조건 설정

### DIFF
--- a/src/components/room/MeetingRoom.tsx
+++ b/src/components/room/MeetingRoom.tsx
@@ -33,10 +33,16 @@ function MeetingRoom({ room }: { room: MeetingRoomType }) {
       // 만약 isActive인 채팅방이 이미 있다면 그 방으로 보내기
       router.replace(`/chat/${alreadyChat[0].chatting_room_id}`);
     }
+
     //아직 인원을 모집중인 경우 + 채팅창이 열리지 않은 경우
     const participants = await totalMember(room_id);
     console.log('participants', participants);
     if (!participants || participants.length === 0) return alert('유효하지 않은 접근입니다.');
+
+    //수락창인 단계에서 내가 이미 방에 참여하고 있는 경우
+    if (participants.find((member) => member.user_id === user[0].user_id)) {
+      return router.push(`/meetingRoom/${room_id}`);
+    }
 
     //room의 정보를 가져와서 성별에 할당된 인원을 확인
     const genderMaxNumber = await getmaxGenderMemberNumber(member_number);


### PR DESCRIPTION
### 📌 관련 이슈
closed #94

### Task TODOLIST

- [ ]  같은 수락창에 동일한 유저가 두명이 되지 않도록 조건 설정

### ✨ 개발 내용

<!-- 개발에 대한 내용을 적어주세요 -->
components/room/MeetingRoom:
방에 참여한 사람 목록 중 클릭한 사람의 user_id가 있는 경우 참여한 사람 목록에 추가하지 않고 바로 이동한다.
```
    //수락창인 단계에서 내가 이미 방에 참여하고 있는 경우
    if (participants.find((member) => member.user_id === user[0].user_id)) {
      return router.push(`/meetingRoom/${room_id}`);
    }

```

### TroubleShotting

<!-- TroubleShotting이 있었다면 이야기 해주세요! -->

### 📸 스크린샷(선택)
<img width="950" alt="스크린샷 2024-04-07 오후 5 13 44" src="https://github.com/Team-MeetGo/MeetGO/assets/140328307/cbfc0cfd-50de-45db-aa18-ee970869075b">

<img width="950" alt="스크린샷 2024-04-07 오후 5 14 02" src="https://github.com/Team-MeetGo/MeetGO/assets/140328307/3f939bcf-3947-4f3c-b5a8-14e97993aa30">

이미 참여하고 있는 방 리스트의 방에 방문해도 같은 유저가 둘이 되지 않는다.

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

```

```
