### PR TITLE
황인정 - [feat]: 채팅창 추가기능

### DIFF
--- a/src/components/chat/chatBody/ChatList.tsx
+++ b/src/components/chat/chatBody/ChatList.tsx
@@ -28,7 +28,7 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
   const room = useRoomDataQuery(chatRoomId);
   const roomId = room?.roomId;
   const lastMsgId = useMyLastMsgs(user?.id!, chatRoomId);
-  console.log('lastMsgId => ', lastMsgId && lastMsgId[0].last_msg_id);
+  // console.log('lastMsgId => ', lastMsgId && lastMsgId[0].last_msg_id);
   const prevMsgsLengthRef = useRef(messages.length);
   const lastDivRefs = useRef(messages);
 
@@ -175,7 +175,9 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
             lastMsgId[0]?.last_msg_id === msg.message_id &&
             isScrolling &&
             checkedLastMsg ? (
-              <p>여기까지 읽으셨습니다.</p>
+              <div className={`flex ${msg.send_from === user?.id ? 'ml-auto' : 'mr-auto'}`}>
+                <p>여기까지 읽으셨습니다.</p>
+              </div>
             ) : null}
           </>
         ))}

--- a/src/components/chat/chatBody/ChatList.tsx
+++ b/src/components/chat/chatBody/ChatList.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Message } from '(@/types/chatTypes)';
-import { getformattedDate } from '(@/utils)';
+import { getformattedDate, showingDate } from '(@/utils)';
 import { clientSupabase } from '(@/utils/supabase/client)';
 import { useEffect, useRef, useState } from 'react';
 import { User } from '@supabase/supabase-js';
@@ -31,6 +31,12 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
   // console.log('lastMsgId => ', lastMsgId && lastMsgId[0].last_msg_id);
   const prevMsgsLengthRef = useRef(messages.length);
   const lastDivRefs = useRef(messages);
+
+  console.log('쌩 날짜 =>', messages[0].created_at);
+  const date = new Date(messages[0].created_at);
+  console.log('만진 날짜 =>', date);
+  console.log(typeof date);
+  console.log(date.getDate());
 
   const pathname = usePathname();
   const { mutate: mutateToUpdate } = useUpdateLastMsg(
@@ -164,6 +170,11 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
         {hasMore ? <LoadChatMore chatRoomId={chatRoomId} count={count} setCount={setCount} /> : <></>}
         {messages?.map((msg, idx) => (
           <>
+            {idx >= 1 && new Date(msg.created_at).getDate() > new Date(messages[idx - 1].created_at).getDate() ? (
+              <div className="mx-auto">
+                <p>{showingDate(msg.created_at)}</p>
+              </div>
+            ) : null}
             {msg.send_from === user?.id ? (
               <MyChat msg={msg} key={msg.message_id} idx={idx} lastDivRefs={lastDivRefs} />
             ) : (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,13 @@ export const getformattedDate = (date: string) =>
     minute: '2-digit'
   });
 
+export const showingDate = (date: string) =>
+  new Date(date).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+
 export const getFromTo = (loadCount: number, idx: number) => {
   let from = loadCount * (idx + 1);
   let to = from + idx;


### PR DESCRIPTION
 ### 📌 관련 이슈

#128 

### Task TODOLIST
- [x] 나가기 버튼을 누르면 다시 못 들어온다는 경고창 띄우기
- [x] 처음에 모든 메세지 다 불러오던 것 서버 요청 줄이기 위해 조금만 불러오도록 수정
- [x] 모든 메세지에 알림 보다는 내가 들어가 있는 채팅창들에 새로운 메세지 수 구독(로비에 추후 추가예정)
- [x] 마지막 메세지 기억하기 위해 remember_last_msg 테이블 생성
- [x] 마지막 메세지 스크롤, style, 기능구현
- [x] 1일 지날 시 날짜 표시

### ✨ 개발 내용

**- 나가기 버튼을 누르면 다시 못 들어온다는 경고창 띄우기**
![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/e422cea5-4164-4bde-9b93-8ff010ecfec2)

**- 처음에 모든 메세지 다 불러오던 것 서버 요청 줄이기 위해 조금만 불러오도록 수정**
![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/b961c5d5-17b4-45ea-970a-fb93c03f1db8)

**- 모든 메세지에 알림 보다는 내가 들어가 있는 채팅창들에 새로운 메세지 수 구독(로비에 추후 추가예정)**
![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/8321a10a-035f-4c44-83c6-dd51d9771a0b)

**- 마지막 메세지 스크롤, style, 기능구현
ChatList.tsx**
```
`useEffect(() => {
    const scrollBox = scrollRef.current;
    if (scrollBox && !isScrolling) {
      // 처음에 로드 시 스크롤 중이 아닐 때
      if (lastMsgId && lastMsgId.length && lastMsgId[0].last_msg_id !== messages[messages.length - 1].message_id) {
        // 이전에 저장된 마지막 메세지가 있으면 그 메세지 강조처리
        // let lastDiv = document.getElementById(`${lastMsgId[0].last_msg_id}`);
        let ref = lastDivRefs.current.find((ref) => ref.message_id === lastMsgId[0].last_msg_id);
        let lastDiv = ref && ref.current;
        if (lastDiv) {
          setLastCheckedDiv(lastDiv);
          makeHereText(lastDiv);
          setCheckedLastMsg(true);
        }
      } else {
        scrollBox.scrollTop = scrollBox.scrollHeight;
      }
    }
    // 처음 로드 시에만 실행(의존성배열 = [])
  }, []);

  useEffect(() => {
    const scrollBox = scrollRef.current;
    if (scrollBox && !isScrolling) {
      // 처음에 로드 시 스크롤 중이 아닐 때
      if (!lastMsgId || !lastMsgId?.length || prevMsgsLengthRef.current !== messages.length) {
        // 이전에 저장된 마지막 메세지가 없으면 그냥 스크롤 다운
        scrollBox.scrollTop = scrollBox.scrollHeight;
        prevMsgsLengthRef.current = messages.length;
      } else {
        // 이전에 저장된 마지막 메세지가 있고 그게 강조처리 되어있다가, 스크롤다운(마지막 메세지를 확인)되면 투명으로 변경
        if (checkedLastMsg && lastCheckedDiv) {
          setCheckedLastMsg(false);
          lastCheckedDiv.style.display = 'none';
        }
      }
    }
  }, [messages, isScrolling]);

  // 마지막으로 읽은 메세지 기억하기
  useEffect(() => {
    return () => {
      // 현재 나누는 메세지가 있을 때
      if (messages.length) {
        // 이전에 저장된 마지막 메세지가 있으면 현재 메세지 중 마지막 걸로 업데이트, 없으면 현재 메세지 중 마지막 메세지 추가하기
        lastMsgId?.length ? mutateToUpdate() : mutateToAdd();
      }
    };
    // 주소가 바뀔 때만 감지해서 저장 또는 업데이트
  }, [pathname]);`
```

**- 1일 지날 시 날짜 표시**

![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/3c31785a-0a7f-486e-bd18-267ac207751a)


### 🚨 TroubleShotting

- 마지막 메세지를 DB에 업데이트를 하자마자 invalidateQueries가 되어서 마지막 메세지가 표시되었다가 금방 사라지는 이슈
- 업데이트 되지 않아야 마지막 메세지 표시를 유지할 수 있는데, 업데이트가 됨
**WHY?**  
useQuery key와 mutation key를 공유하기 때문에 
=> useQuery key와 mutateToAdd / mutateToUpdate key를 구분함

### 📸 스크린샷(선택)

![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/88f66eb7-ce6c-4c2d-8618-37a896a8ca48)

![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/4688a19b-8d6b-433f-b74e-08bec6225f72)

![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/4688a19b-8d6b-433f-b74e-08bec6225f72)




