### PR TITLE
황인정 - [feat]: 채팅창 여기까지 읽었습니다 수정

### DIFF
--- a/src/app/chat/[chatroom_id]/page.tsx
+++ b/src/app/chat/[chatroom_id]/page.tsx
@@ -26,8 +26,8 @@ const ChatPage = async ({ params }: { params: { chatroom_id: string } }) => {
     <Suspense fallback={<ChatLoading />}>
       <div className="flex felx-row">
         <InitChat user={user} chatRoomId={chatRoomId} allMsgs={allMsgs ?? []} />
-        <SideBar chatRoomId={chatRoomId} />
-        {/* <div className="w-full max-w-2xl mx-auto md:py-10 h-screen">
+        {/* <SideBar chatRoomId={chatRoomId} /> */}
+        <div className="w-full max-w-2xl mx-auto md:py-8 h-screen">
           <div className="h-full border rounded-md flex flex-col border-indigo-600 relative">
             <ChatHeader chatRoomId={chatRoomId} />
             <Suspense fallback="skeleton 들어갈 자리">
@@ -35,7 +35,7 @@ const ChatPage = async ({ params }: { params: { chatroom_id: string } }) => {
             </Suspense>
             <ChatInput />
           </div>
-        </div> */}
+        </div>
       </div>
     </Suspense>
   );

--- a/src/app/users/join/page.tsx
+++ b/src/app/users/join/page.tsx
@@ -1,5 +1,4 @@
 import JoinForm from '(@/components/user/JoinForm)';
-
 const JoinPage = () => {
   return (
     <div className="w-full m-auto flex flex-col justify-center items-center min-h-screen absolute top-0">

--- a/src/components/chat/chatBody/ChatList.tsx
+++ b/src/components/chat/chatBody/ChatList.tsx
@@ -32,8 +32,8 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
   const lastDivRefs = useRef(messages);
   const lastMsgId = useMyLastMsgs(user?.id!, chatRoomId);
 
-  console.log('DB의 마지막 메세지 =>', lastMsgId);
-  console.log('찐 마지막 메세지 =>', messages[messages.length - 1].message_id);
+  // console.log('DB의 마지막 메세지 =>', lastMsgId);
+  // console.log('찐 마지막 메세지 =>', messages[messages.length - 1].message_id);
 
   useEffect(() => {
     if (roomId && chatRoomId) {
@@ -123,12 +123,12 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
   useEffect(() => {
     console.log('useEffect 안 실행되는 건 맞아?');
     // 현재 나누는 메세지가 있을 때
-
     return () => {
       console.log('실행은 되니');
-      console.log(checkedLastMsg && messages.length);
       // 이전에 저장된 마지막 메세지가 있으면 현재 메세지 중 마지막 걸로 업데이트, 없으면 현재 메세지 중 마지막 메세지 추가하기
-      lastMsgId ? mutateToUpdate() : mutateToAdd();
+      if (messages.length) {
+        lastMsgId ? mutateToUpdate() : mutateToAdd();
+      }
     };
   }, [checkedLastMsg]);
 

--- a/src/components/chat/chatBody/ChatList.tsx
+++ b/src/components/chat/chatBody/ChatList.tsx
@@ -1,19 +1,15 @@
 'use client';
 import { Message } from '(@/types/chatTypes)';
-import { getformattedDate, showingDate } from '(@/utils)';
 import { clientSupabase } from '(@/utils/supabase/client)';
 import { useEffect, useRef, useState } from 'react';
 import { User } from '@supabase/supabase-js';
 import ChatScroll from './ChatScroll';
 import NewChatAlert from './NewChatAlert';
 import LoadChatMore from './LoadChatMore';
-import ChatDeleteDropDown from './ChatDeleteDropDown';
 import { chatStore } from '(@/store/chatStore)';
-import { Tooltip } from '@nextui-org/react';
 import OthersChat from './OthersChat';
 import ChatSearch from './ChatSearch';
 import { useMyLastMsgs, useRoomDataQuery } from '(@/hooks/useQueries/useChattingQuery)';
-import { usePathname } from 'next/navigation';
 import { useAddLastMsg, useUpdateLastMsg } from '(@/hooks/useMutation/useChattingMutation)';
 import MyChat from './MyChat';
 

--- a/src/components/chat/chatBody/ChatList.tsx
+++ b/src/components/chat/chatBody/ChatList.tsx
@@ -19,39 +19,21 @@ import MyChat from './MyChat';
 
 const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string }) => {
   const scrollRef = useRef() as React.MutableRefObject<HTMLDivElement>;
-  const { hasMore, messages, checkedLastMsg, isScrolling, setMessages, setCheckedLastMsg, setIsScrolling } = chatStore(
-    (state) => state
-  );
-  // const [isScrolling, setIsScrolling] = useState(false);
+  const { hasMore, messages, setMessages } = chatStore((state) => state);
+  const [isScrolling, setIsScrolling] = useState(false);
   const [isScrollTop, setIsScrollTop] = useState(true);
   const [count, setCount] = useState(1);
   const [newAddedMsgNum, setNewAddedMsgNum] = useState(0);
   const [lastCheckedDiv, setLastCheckedDiv] = useState<HTMLElement | null>();
-  // const [checkedLastMsg, setCheckedLastMsg] = useState(false);
-  console.log('checkedLastMsg =>', checkedLastMsg);
-  console.log('메세지 있어? =>', messages.length > 0);
+  const [checkedLastMsg, setCheckedLastMsg] = useState(false);
   const room = useRoomDataQuery(chatRoomId);
   const roomId = room?.roomId;
-
-  console.log('messages =>', messages);
   const prevMsgsLengthRef = useRef(messages.length);
   const lastDivRefs = useRef(messages);
-
   const lastMsgId = useMyLastMsgs(user?.id!, chatRoomId);
 
   console.log('DB의 마지막 메세지 =>', lastMsgId);
   console.log('찐 마지막 메세지 =>', messages[messages.length - 1].message_id);
-
-  const { mutate: mutateToUpdate } = useUpdateLastMsg(
-    user?.id as string,
-    chatRoomId as string,
-    messages && messages.length > 0 ? messages[messages.length - 1].message_id : undefined
-  );
-  const { mutate: mutateToAdd } = useAddLastMsg(
-    chatRoomId,
-    user?.id as string,
-    messages && messages.length > 0 ? messages[messages.length - 1].message_id : undefined
-  );
 
   useEffect(() => {
     if (roomId && chatRoomId) {
@@ -110,7 +92,9 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
     const scrollBox = scrollRef.current;
     if (scrollBox && !isScrolling) {
       // 처음에 로드 시 스크롤 중이 아닐 때
-      if (!lastMsgId || !lastCheckedDiv || prevMsgsLengthRef.current !== messages.length) {
+      let ref = lastDivRefs.current.find((ref) => ref.message_id === lastMsgId);
+      let lastDiv = ref && ref.current;
+      if (!lastMsgId || prevMsgsLengthRef.current !== messages.length || !lastDiv) {
         // 이전에 저장된 마지막 메세지가 없거나, DB에 저장된 메세지는 있는데 화면에 없거나, 새로운 메세지가 추가될 때 그냥 스크롤 다운
         scrollBox.scrollTop = scrollBox.scrollHeight;
         prevMsgsLengthRef.current = messages.length;
@@ -118,11 +102,22 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
         // 이전에 저장된 마지막 메세지가 있고 그게 강조처리 되어있다가, 스크롤다운(마지막 메세지를 확인)되면 투명으로 변경
         if (lastCheckedDiv) {
           setCheckedLastMsg(true);
-          lastCheckedDiv.style.display = 'none';
+          lastCheckedDiv.style.backgroundColor = '';
         }
       }
     }
   }, [messages, isScrolling]);
+
+  const { mutate: mutateToUpdate } = useUpdateLastMsg(
+    user?.id as string,
+    chatRoomId as string,
+    messages && messages.length > 0 ? messages[messages.length - 1].message_id : undefined
+  );
+  const { mutate: mutateToAdd } = useAddLastMsg(
+    chatRoomId,
+    user?.id as string,
+    messages && messages.length > 0 ? messages[messages.length - 1].message_id : undefined
+  );
 
   // 마지막으로 읽은 메세지 기억하기
   useEffect(() => {
@@ -132,10 +127,8 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
     return () => {
       console.log('실행은 되니');
       console.log(checkedLastMsg && messages.length);
-      // if (checkedLastMsg && messages.length) {
       // 이전에 저장된 마지막 메세지가 있으면 현재 메세지 중 마지막 걸로 업데이트, 없으면 현재 메세지 중 마지막 메세지 추가하기
-      // lastMsgId ? mutateToUpdate() : mutateToAdd();
-      // }
+      lastMsgId ? mutateToUpdate() : mutateToAdd();
     };
   }, [checkedLastMsg]);
 
@@ -170,16 +163,26 @@ const ChatList = ({ user, chatRoomId }: { user: User | null; chatRoomId: string 
         onScroll={handleScroll}
       >
         <ChatSearch isScrollTop={isScrollTop} />
+
         {hasMore ? <LoadChatMore chatRoomId={chatRoomId} count={count} setCount={setCount} /> : <></>}
-        <>
-          {messages?.map((msg, idx) =>
-            msg.send_from === user?.id ? (
+        {messages?.map((msg, idx) => (
+          <>
+            {msg.send_from === user?.id ? (
               <MyChat msg={msg} key={msg.message_id} idx={idx} lastDivRefs={lastDivRefs} />
             ) : (
               <OthersChat msg={msg} key={msg.message_id} idx={idx} lastDivRefs={lastDivRefs} />
-            )
-          )}
-        </>
+            )}
+            {lastMsgId &&
+            lastMsgId !== messages[messages.length - 1].message_id &&
+            lastMsgId === msg.message_id &&
+            isScrolling &&
+            !checkedLastMsg ? (
+              <div className={`flex ${msg.send_from === user?.id ? 'ml-auto' : 'mr-auto'}`}>
+                <p>여기까지 읽으셨습니다.</p>
+              </div>
+            ) : null}
+          </>
+        ))}
       </div>
       {isScrolling ? (
         newAddedMsgNum === 0 ? (

--- a/src/components/chat/chatBody/MyChat.tsx
+++ b/src/components/chat/chatBody/MyChat.tsx
@@ -4,16 +4,15 @@ import { chatStore } from '(@/store/chatStore)';
 import { Message } from '(@/types/chatTypes)';
 import { getformattedDate, showingDate } from '(@/utils)';
 import ChatDeleteDropDown from './ChatDeleteDropDown';
-import { Tooltip } from '@nextui-org/react';
 
 const MyChat = ({ msg, idx, lastDivRefs }: { msg: Message; idx: number; lastDivRefs: any }) => {
   const { messages, chatRoomId, checkedLastMsg, isScrolling } = chatStore((state) => state);
   const { data: user } = useGetUserDataQuery();
   const lastMsgId = useMyLastMsgs(user?.user_id!, chatRoomId);
   return (
-    <div key={msg.message_id}>
+    <>
       {idx >= 1 && new Date(msg.created_at).getDate() > new Date(messages[idx - 1].created_at).getDate() ? (
-        <div className="mx-auto">
+        <div className="mx-auto" key={msg.message_id}>
           <p>{showingDate(msg.created_at)}</p>
         </div>
       ) : null}
@@ -29,20 +28,9 @@ const MyChat = ({ msg, idx, lastDivRefs }: { msg: Message; idx: number; lastDivR
             <p>{getformattedDate(msg.created_at)}</p>
           </div>
         </div>
-        <Tooltip content="여기 컴포넌트">
-          <div className="h-14 w-14 bg-indigo-600 rounded-full my-auto">{msg.avatar}</div>
-        </Tooltip>
+        <div className="h-14 w-14 bg-indigo-600 rounded-full my-auto">{msg.avatar}</div>
       </div>
-      {lastMsgId &&
-      lastMsgId !== messages[messages.length - 1].message_id &&
-      lastMsgId === msg.message_id &&
-      isScrolling &&
-      !checkedLastMsg ? (
-        <div className={`flex ${msg.send_from === user?.user_id ? 'ml-auto' : 'mr-auto'}`}>
-          <p>여기까지 읽으셨습니다.</p>
-        </div>
-      ) : null}
-    </div>
+    </>
   );
 };
 

--- a/src/components/chat/chatBody/OthersChat.tsx
+++ b/src/components/chat/chatBody/OthersChat.tsx
@@ -43,15 +43,6 @@ const OthersChat = ({ msg, idx, lastDivRefs }: { msg: Message; idx: number; last
           </div>
         </div>
       </div>
-      {lastMsgId &&
-      lastMsgId !== messages[messages.length - 1].message_id &&
-      lastMsgId === msg.message_id &&
-      isScrolling &&
-      !checkedLastMsg ? (
-        <div className={`flex ${msg.send_from === user?.user_id ? 'ml-auto' : 'mr-auto'}`}>
-          <p>여기까지 읽으셨습니다.</p>
-        </div>
-      ) : null}
     </div>
   );
 };

--- a/src/components/common/NavBarContents.tsx
+++ b/src/components/common/NavBarContents.tsx
@@ -66,11 +66,11 @@ const NavBarContents = () => {
             리뷰게시판
           </Link>
         </NavbarItem>
-        {/* <NavbarItem>
-            <Link color="foreground" href="#">
-              메뉴더있었으면..
-            </Link>
-          </NavbarItem> */}
+        <NavbarItem>
+          <Link color="foreground" href="/test">
+            test
+          </Link>
+        </NavbarItem>
       </NavbarContent>
 
       <NavbarContent className="h-auto" as="div" justify="end">

--- a/src/components/user/JoinForm.tsx
+++ b/src/components/user/JoinForm.tsx
@@ -47,7 +47,9 @@ const JoinForm = () => {
       type: 'alert',
       name: '',
       text: '회원가입 되었습니다.',
-      onFunc: () => {}
+      onFunc: () => {
+        router.replace('/');
+      }
     });
   };
 


### PR DESCRIPTION
### 📌 관련 이슈
#128 

### 🚨 TroubleShotting
- 마지막 메세지를 가져오는 useQuery key와 mutation key를 다르게 했을 때, 새로운 값이 갱신되지 않는 이슈(당연...ㅠ)
- 하지만 컴포넌트가 마운트 되자마자 invalidateQueries가 되어서는 안 됨
- useEffect의 clean up 함수를 이용해서 컴포넌트가 unmount 될 때만 mutation 함수가 실행되도록 설정했으나,
- clean up 함수가 컴포넌트 마운트 시 실행되는 이슈 

### ✨ 개발 내용
- next.config.mjs 파일에 reactStrictMode: false 추가
- 네브 바에 Link 태그 잘못 import 되어있는 것도 반영

### 📸 스크린샷(선택)
![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/53e3d80e-acfa-46e4-9ba0-7f1b34f1897a)




