### PR TITLE
황인정: [fix] - 채팅방 날짜, 시간 Realtime

### DIFF
--- a/src/components/chat/chatHeader/InitChat.tsx
+++ b/src/components/chat/chatHeader/InitChat.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { useRoomDataQuery } from '@/hooks/useQueries/useChattingQuery';
+import { CHATDATA_QUERY_KEY } from '@/query/chat/chatQueryKeys';
 import { chatStore } from '@/store/chatStore';
 import { Message, chatRoomPayloadType } from '@/types/chatTypes';
 import { ITEM_INTERVAL } from '@/utils/constant';
 import { clientSupabase } from '@/utils/supabase/client';
 import { User } from '@supabase/supabase-js';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -13,6 +15,7 @@ const InitChat = ({ chatRoomId, allMsgs }: { user: User | null; chatRoomId: stri
   const room = useRoomDataQuery(chatRoomId);
   const roomId = room?.room_id;
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     // 채팅방 isActive 상태 구독
@@ -22,7 +25,12 @@ const InitChat = ({ chatRoomId, allMsgs }: { user: User | null; chatRoomId: stri
         'postgres_changes',
         { event: 'UPDATE', schema: 'public', table: 'chatting_room', filter: `chatting_room_id=eq.${chatRoomId}` },
         (payload) => {
+          console.log(payload.new);
+          console.log('두번?');
           setChatState((payload.new as chatRoomPayloadType).isActive);
+          // queryClient.invalidateQueries({
+          //   queryKey: [CHATDATA_QUERY_KEY]
+          // });
         }
       )
       .subscribe();

--- a/src/components/chat/chatHeader/InitChat.tsx
+++ b/src/components/chat/chatHeader/InitChat.tsx
@@ -10,7 +10,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
-const InitChat = ({ chatRoomId, allMsgs }: { user: User | null; chatRoomId: string; allMsgs: Message[] }) => {
+const InitChat = ({ user, chatRoomId, allMsgs }: { user: User | null; chatRoomId: string; allMsgs: Message[] }) => {
   const { chatState, isRest, setChatState, setMessages, setChatRoomId, setHasMore } = chatStore((state) => state);
   const room = useRoomDataQuery(chatRoomId);
   const roomId = room?.room_id;
@@ -26,9 +26,11 @@ const InitChat = ({ chatRoomId, allMsgs }: { user: User | null; chatRoomId: stri
         { event: 'UPDATE', schema: 'public', table: 'chatting_room', filter: `chatting_room_id=eq.${chatRoomId}` },
         (payload) => {
           setChatState((payload.new as chatRoomPayloadType).isActive);
-          queryClient.invalidateQueries({
-            queryKey: [CHATDATA_QUERY_KEY]
-          });
+          if (user?.id !== room?.leader_id) {
+            queryClient.invalidateQueries({
+              queryKey: [CHATDATA_QUERY_KEY]
+            });
+          }
         }
       )
       .subscribe();

--- a/src/components/chat/chatHeader/InitChat.tsx
+++ b/src/components/chat/chatHeader/InitChat.tsx
@@ -25,12 +25,10 @@ const InitChat = ({ chatRoomId, allMsgs }: { user: User | null; chatRoomId: stri
         'postgres_changes',
         { event: 'UPDATE', schema: 'public', table: 'chatting_room', filter: `chatting_room_id=eq.${chatRoomId}` },
         (payload) => {
-          console.log(payload.new);
-          console.log('두번?');
           setChatState((payload.new as chatRoomPayloadType).isActive);
-          // queryClient.invalidateQueries({
-          //   queryKey: [CHATDATA_QUERY_KEY]
-          // });
+          queryClient.invalidateQueries({
+            queryKey: [CHATDATA_QUERY_KEY]
+          });
         }
       )
       .subscribe();

--- a/src/components/chat/sidebar/DateTimePicker.tsx
+++ b/src/components/chat/sidebar/DateTimePicker.tsx
@@ -10,7 +10,6 @@ import { useRoomDataQuery } from '@/hooks/useQueries/useChattingQuery';
 import { useUpdateMeetingTimeMutation } from '@/hooks/useMutation/useMeetingTimeMutation';
 import { useGetUserDataQuery } from '@/hooks/useQueries/useUserQuery';
 import { DateTimePickerProps } from '@/types/sideBarTypes';
-import { useQueryClient } from '@tanstack/react-query';
 
 const DateTimePicker: React.FC<DateTimePickerProps> = forwardRef(({ chatRoomId }, ref) => {
   const [selectedMeetingTime, setSelectedMeetingTime] = useState<Date | null>(new Date());
@@ -25,39 +24,9 @@ const DateTimePicker: React.FC<DateTimePickerProps> = forwardRef(({ chatRoomId }
   const toggleCalendar = () => {
     setIsCalendarOpen(!isCalendarOpen);
   };
-  // const chat = useChatDataQuery(chatRoomId);
-  const queryClient = useQueryClient();
-
-  // useEffect(() => {
-  //   const meetingTime = new Date(String(chat?.meeting_time));
-  //   if (meetingTime instanceof Date && !isNaN(meetingTime.getTime())) {
-  //     setSelectedMeetingTime(meetingTime);
-  //   }
-  // }, [chatRoomId, chat]);
 
   const { mutate: updateMeetingTime } = useUpdateMeetingTimeMutation();
 
-  // useEffect(() => {
-  //   if (leaderId !== userId) {
-  //     const channel = clientSupabase
-  //       .channel(`${chatRoomId}_meetingTimeNLocation`)
-  //       .on(
-  //         'postgres_changes',
-  //         { event: 'UPDATE', schema: 'public', table: 'chatting_room', filter: `chatting_room_id=eq.${chatRoomId}` },
-  //         (payload) => {
-  //           console.log(payload.new);
-  //           queryClient.invalidateQueries({
-  //             queryKey: [CHATDATA_QUERY_KEY]
-  //           });
-  //         }
-  //       )
-  //       .subscribe();
-  //     return () => {
-  //       clientSupabase.removeChannel(channel);
-  //     };
-  //   }
-  // }, [chatRoomId, leaderId, queryClient, userId]);
-  // months 배열을 선언
   const months = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
   return (
     <div className="relative z-50 w-full max-w-lg py-6">
@@ -67,15 +36,14 @@ const DateTimePicker: React.FC<DateTimePickerProps> = forwardRef(({ chatRoomId }
         wrapperClassName="w-full z-100"
         selected={selectedMeetingTime ? selectedMeetingTime : new Date()}
         onChange={(date) => {
-          // if (leaderId == userId) {
-          setSelectedMeetingTime(date as Date);
-          const isoStringMeetingTime = date?.toISOString();
-          updateMeetingTime({
-            chatRoomId,
-            isoStringMeetingTime: String(isoStringMeetingTime)
-          });
-
-          // }
+          if (leaderId == userId) {
+            setSelectedMeetingTime(date as Date);
+            const isoStringMeetingTime = date?.toISOString();
+            updateMeetingTime({
+              chatRoomId,
+              isoStringMeetingTime: String(isoStringMeetingTime)
+            });
+          }
         }}
         minDate={new Date()} // 오늘 이전의 날짜 선택 불가능
         showTimeSelect

--- a/src/components/chat/sidebar/Map.tsx
+++ b/src/components/chat/sidebar/Map.tsx
@@ -25,8 +25,6 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   const [searchText, setSearchText] = useState<string>('');
   const [selectedMeetingLocation, setSelectedMeetingLocation] = useState<string>();
 
-  console.log('selectedMeetingLocation =>', selectedMeetingLocation);
-
   // 유저 정보 가져오기
   const { data: userData } = useGetUserDataQuery();
   const userId = userData?.user_id;
@@ -38,7 +36,6 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   // 채팅방 정보 가져오기
   const chat = useChatDataQuery(chatRoomId);
   const meetingLocation = chat?.meeting_location;
-  console.log('meetingLocation =>', meetingLocation);
 
   useEffect(() => {
     const script = document.createElement('script');

--- a/src/components/chat/sidebar/Map.tsx
+++ b/src/components/chat/sidebar/Map.tsx
@@ -37,6 +37,9 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   const chat = useChatDataQuery(chatRoomId);
   const meetingLocation = chat?.meeting_location;
 
+  // useMutation 호출
+  const updateMeetingLocationMutation = useUpdateMeetingLocationMutation();
+
   useEffect(() => {
     const script = document.createElement('script');
     script.async = true;
@@ -176,8 +179,6 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
     setCurrentPage(pageNumber);
     searchBarsNearby(mapRef.current, pageNumber);
   };
-  // useMutation 호출
-  const updateMeetingLocationMutation = useUpdateMeetingLocationMutation();
 
   // 장소 선택 함수
   const handleSelectLocation = (barName: string) => {

--- a/src/components/chat/sidebar/Map.tsx
+++ b/src/components/chat/sidebar/Map.tsx
@@ -5,10 +5,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Card, CardBody, Pagination } from '@nextui-org/react';
 import { HiMiniMagnifyingGlass } from 'react-icons/hi2';
 import DateTimePicker from './DateTimePicker';
-import {
-  // useClearMeetingLocationMutation,
-  useUpdateMeetingLocationMutation
-} from '@/hooks/useMutation/useMeetingLocationMutation';
+import { useUpdateMeetingLocationMutation } from '@/hooks/useMutation/useMeetingLocationMutation';
 import { useGetUserDataQuery } from '@/hooks/useQueries/useUserQuery';
 import { MapProps } from '@/types/sideBarTypes';
 
@@ -26,7 +23,6 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   const [totalPages, setTotalPages] = useState(0);
   const [currentPos, setCurrentPos] = useState<string>();
   const [searchText, setSearchText] = useState<string>('');
-  // const [isLocationSelected, setIsLocationSelected] = useState<boolean>(false);
   const [selectedMeetingLocation, setSelectedMeetingLocation] = useState<string>();
 
   console.log('selectedMeetingLocation =>', selectedMeetingLocation);
@@ -43,11 +39,6 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   const chat = useChatDataQuery(chatRoomId);
   const meetingLocation = chat?.meeting_location;
   console.log('meetingLocation =>', meetingLocation);
-
-  // useEffect(() => {
-  //   setSelectedMeetingLocation(meetingLocation || '');
-  //   // setIsLocationSelected(!!meetingLocation);
-  // }, [meetingLocation]);
 
   useEffect(() => {
     const script = document.createElement('script');
@@ -190,30 +181,14 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   };
   // useMutation 호출
   const updateMeetingLocationMutation = useUpdateMeetingLocationMutation();
-  // const clearMeetingLocationMutation = useClearMeetingLocationMutation();
 
   // 장소 선택 함수
   const handleSelectLocation = (barName: string) => {
-    console.log('barName =>', barName);
     setSelectedMeetingLocation(barName);
-    // setIsLocationSelected(!isLocationSelected);
     if (!chatRoomId) {
       return;
     }
-
-    // if (barName === selectedMeetingLocation) {
-    //   try {
-    //     await clearMeetingLocationMutation.mutateAsync(chatRoomId);
-    //   } catch (error) {
-    //     console.error('미팅장소 삭제 오류:', error);
-    //   }
-    // } else {
-    //   try {
     updateMeetingLocationMutation.mutate({ chatRoomId, barName });
-    //   } catch (error) {
-    //     console.error('미팅장소 업데이트 오류:', error);
-    //   }
-    // }
   };
 
   return (
@@ -269,9 +244,9 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
             <div
               className="py-4 px-9"
               onClick={() => {
-                // if (userId === leaderId) {
-                handleSelectLocation(bar.place_name);
-                // }
+                if (userId === leaderId) {
+                  handleSelectLocation(bar.place_name);
+                }
               }}
               style={{ cursor: 'pointer', alignItems: 'center' }}
             >

--- a/src/components/chat/sidebar/Map.tsx
+++ b/src/components/chat/sidebar/Map.tsx
@@ -6,7 +6,7 @@ import { Card, CardBody, Pagination } from '@nextui-org/react';
 import { HiMiniMagnifyingGlass } from 'react-icons/hi2';
 import DateTimePicker from './DateTimePicker';
 import {
-  useClearMeetingLocationMutation,
+  // useClearMeetingLocationMutation,
   useUpdateMeetingLocationMutation
 } from '@/hooks/useMutation/useMeetingLocationMutation';
 import { useGetUserDataQuery } from '@/hooks/useQueries/useUserQuery';
@@ -26,8 +26,10 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   const [totalPages, setTotalPages] = useState(0);
   const [currentPos, setCurrentPos] = useState<string>();
   const [searchText, setSearchText] = useState<string>('');
-  const [isLocationSelected, setIsLocationSelected] = useState<boolean>(false);
+  // const [isLocationSelected, setIsLocationSelected] = useState<boolean>(false);
   const [selectedMeetingLocation, setSelectedMeetingLocation] = useState<string>();
+
+  console.log('selectedMeetingLocation =>', selectedMeetingLocation);
 
   // 유저 정보 가져오기
   const { data: userData } = useGetUserDataQuery();
@@ -40,11 +42,12 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   // 채팅방 정보 가져오기
   const chat = useChatDataQuery(chatRoomId);
   const meetingLocation = chat?.meeting_location;
+  console.log('meetingLocation =>', meetingLocation);
 
-  useEffect(() => {
-    setSelectedMeetingLocation(meetingLocation || '');
-    setIsLocationSelected(!!meetingLocation);
-  }, [meetingLocation]);
+  // useEffect(() => {
+  //   setSelectedMeetingLocation(meetingLocation || '');
+  //   // setIsLocationSelected(!!meetingLocation);
+  // }, [meetingLocation]);
 
   useEffect(() => {
     const script = document.createElement('script');
@@ -187,29 +190,30 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
   };
   // useMutation 호출
   const updateMeetingLocationMutation = useUpdateMeetingLocationMutation();
-  const clearMeetingLocationMutation = useClearMeetingLocationMutation();
+  // const clearMeetingLocationMutation = useClearMeetingLocationMutation();
 
   // 장소 선택 함수
-  const handleSelectLocation = async (barName: string) => {
+  const handleSelectLocation = (barName: string) => {
+    console.log('barName =>', barName);
     setSelectedMeetingLocation(barName);
-    setIsLocationSelected(!isLocationSelected);
+    // setIsLocationSelected(!isLocationSelected);
     if (!chatRoomId) {
       return;
     }
 
-    if (barName === selectedMeetingLocation) {
-      try {
-        await clearMeetingLocationMutation.mutateAsync(chatRoomId);
-      } catch (error) {
-        console.error('미팅장소 삭제 오류:', error);
-      }
-    } else {
-      try {
-        await updateMeetingLocationMutation.mutateAsync({ chatRoomId, barName });
-      } catch (error) {
-        console.error('미팅장소 업데이트 오류:', error);
-      }
-    }
+    // if (barName === selectedMeetingLocation) {
+    //   try {
+    //     await clearMeetingLocationMutation.mutateAsync(chatRoomId);
+    //   } catch (error) {
+    //     console.error('미팅장소 삭제 오류:', error);
+    //   }
+    // } else {
+    //   try {
+    updateMeetingLocationMutation.mutate({ chatRoomId, barName });
+    //   } catch (error) {
+    //     console.error('미팅장소 업데이트 오류:', error);
+    //   }
+    // }
   };
 
   return (
@@ -218,8 +222,8 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
         <h1 className="font-semibold text-2xl mb-2">미팅 장소</h1>
         <Card className="h-[60px] border border-mainColor rounded-[9px] shadow-none ">
           <CardBody className=" flex flex-row justify-start items-center text-lg">
-            <p className={selectedMeetingLocation ? '' : 'text-gray2'}>
-              {selectedMeetingLocation ? selectedMeetingLocation : '방장이 선택한 장소가 표시됩니다.'}
+            <p className={meetingLocation ? '' : 'text-gray2'}>
+              {meetingLocation ? meetingLocation : '방장이 선택한 장소가 표시됩니다.'}
             </p>
           </CardBody>
         </Card>
@@ -265,9 +269,9 @@ const Map: React.FC<MapProps> = ({ chatRoomId }) => {
             <div
               className="py-4 px-9"
               onClick={() => {
-                if (userId === leaderId) {
-                  handleSelectLocation(selectedMeetingLocation === bar.place_name ? '' : bar.place_name);
-                }
+                // if (userId === leaderId) {
+                handleSelectLocation(bar.place_name);
+                // }
               }}
               style={{ cursor: 'pointer', alignItems: 'center' }}
             >

--- a/src/components/room/singleMeetingRoom/MeetingRoom.tsx
+++ b/src/components/room/singleMeetingRoom/MeetingRoom.tsx
@@ -55,6 +55,7 @@ function MeetingRoom({ room }: { room: MeetingRoomType }) {
     ) {
       roomMemberMutation();
     }
+
     //모든 인원이 다 찼을 경우 모집종료로 변경
     if (genderMaxNumber && participants?.length === genderMaxNumber * 2 - 1) {
       updateRoomStatusCloseMutation();

--- a/src/components/room/singleMeetingRoom/MeetingRoom.tsx
+++ b/src/components/room/singleMeetingRoom/MeetingRoom.tsx
@@ -8,7 +8,6 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import RoomInformation from './RoomInformation';
 
-type ControlDelay = (callback: (...args: any[]) => void, delay: number) => any;
 import type { MeetingRoomType } from '@/types/roomTypes';
 
 function MeetingRoom({ room }: { room: MeetingRoomType }) {

--- a/src/components/room/singleMeetingRoom/MeetingRoom.tsx
+++ b/src/components/room/singleMeetingRoom/MeetingRoom.tsx
@@ -4,11 +4,9 @@ import { useAddRoomMemberMutation, useUpdateRoomStatusCloseMutation } from '@/ho
 import { useAlreadyChatRoomQuery, useRoomParticipantsQuery } from '@/hooks/useQueries/useMeetingQuery';
 import { useGetUserDataQuery } from '@/hooks/useQueries/useUserQuery';
 import MeetGoLogoPurple from '@/utils/icons/meetgo-logo-purple.png';
-import { Chip } from '@nextui-org/react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import RoomInformation from './RoomInformation';
-import { useCallback } from 'react';
 
 type ControlDelay = (callback: (...args: any[]) => void, delay: number) => any;
 import type { MeetingRoomType } from '@/types/roomTypes';

--- a/src/hooks/useMutation/useMeetingLocationMutation.ts
+++ b/src/hooks/useMutation/useMeetingLocationMutation.ts
@@ -9,25 +9,9 @@ export const useUpdateMeetingLocationMutation = () => {
     mutationFn: ({ chatRoomId, barName }: { chatRoomId: string; barName: string }) =>
       updateMeetingLocation({ chatRoomId, barName }),
     onSuccess: async () => {
-      console.log('인발리데이트 되나?');
       await queryClient.invalidateQueries({ queryKey: [CHATDATA_QUERY_KEY] });
     }
   });
 
   return updateMeetingRoomMutation;
 };
-
-// export const useClearMeetingLocationMutation = () => {
-//   const queryClient = useQueryClient();
-
-//   const clearMeetingRoomMutation = useMutation<void, unknown, string>({
-//     mutationFn: async (chatRoomId: string) => {
-//       await deleteMeetingLocation(chatRoomId);
-//     },
-//     onSuccess: () => {
-//       queryClient.invalidateQueries({ queryKey: [CHATDATA_QUERY_KEY] });
-//     }
-//   });
-
-//   return clearMeetingRoomMutation;
-// };

--- a/src/hooks/useMutation/useMeetingLocationMutation.ts
+++ b/src/hooks/useMutation/useMeetingLocationMutation.ts
@@ -1,4 +1,4 @@
-import { addMeetingLocation, deleteMeetingLocation } from '@/query/chat/chatQueryFns';
+import { addMeetingLocation, deleteMeetingLocation, updateMeetingLocation } from '@/query/chat/chatQueryFns';
 import { CHATDATA_QUERY_KEY } from '@/query/chat/chatQueryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -6,27 +6,28 @@ export const useUpdateMeetingLocationMutation = () => {
   const queryClient = useQueryClient();
 
   const updateMeetingRoomMutation = useMutation({
-    mutationFn: async ({ chatRoomId, barName }: { chatRoomId: string; barName: string }) =>
-      await addMeetingLocation({ chatRoomId, barName }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CHATDATA_QUERY_KEY });
+    mutationFn: ({ chatRoomId, barName }: { chatRoomId: string; barName: string }) =>
+      updateMeetingLocation({ chatRoomId, barName }),
+    onSuccess: async () => {
+      console.log('인발리데이트 되나?');
+      await queryClient.invalidateQueries({ queryKey: [CHATDATA_QUERY_KEY] });
     }
   });
 
   return updateMeetingRoomMutation;
 };
 
-export const useClearMeetingLocationMutation = () => {
-  const queryClient = useQueryClient();
+// export const useClearMeetingLocationMutation = () => {
+//   const queryClient = useQueryClient();
 
-  const clearMeetingRoomMutation = useMutation<void, unknown, string>({
-    mutationFn: async (chatRoomId: string) => {
-      await deleteMeetingLocation(chatRoomId);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CHATDATA_QUERY_KEY });
-    }
-  });
+//   const clearMeetingRoomMutation = useMutation<void, unknown, string>({
+//     mutationFn: async (chatRoomId: string) => {
+//       await deleteMeetingLocation(chatRoomId);
+//     },
+//     onSuccess: () => {
+//       queryClient.invalidateQueries({ queryKey: [CHATDATA_QUERY_KEY] });
+//     }
+//   });
 
-  return clearMeetingRoomMutation;
-};
+//   return clearMeetingRoomMutation;
+// };

--- a/src/query/chat/chatQueryFns.ts
+++ b/src/query/chat/chatQueryFns.ts
@@ -192,10 +192,8 @@ export const updateMeetingLocation = async ({ chatRoomId, barName }: { chatRoomI
     .eq('chatting_room_id', chatRoomId)
     .eq('meeting_location', barName);
   if (error) console.error('fail to select meeting_location', error.message);
-  console.log('업데이트 함수 안 barName => ', barName);
 
   if (DBdata && DBdata[0]) {
-    console.log('같은 게 있음!');
     const { data, error } = await clientSupabase
       .from('chatting_room')
       .update({ meeting_location: null })
@@ -203,7 +201,6 @@ export const updateMeetingLocation = async ({ chatRoomId, barName }: { chatRoomI
     if (error) console.error('fail to update meetingLocation to null', error.message);
     return data;
   } else {
-    console.log('같은 게 없어서 바꿈!');
     const { data, error } = await clientSupabase
       .from('chatting_room')
       .update({ meeting_location: barName })

--- a/src/query/chat/chatQueryFns.ts
+++ b/src/query/chat/chatQueryFns.ts
@@ -143,7 +143,7 @@ export const updateMyLastMsg = async (user_id: string, chatRoomId: string, msg_i
     .eq('chatting_room_id', chatRoomId)
     .select('*');
   if (error) console.error('마지막 메세지 업데이트 실패 =>', error.message);
-  return updateMyLastMsg;
+  return updatedLastMsg;
 };
 
 // 안 읽은 메세지 수 추가
@@ -183,4 +183,32 @@ export const addMeetingLocation = async ({ chatRoomId, barName }: { chatRoomId: 
 // 미팅 장소 제거
 export const deleteMeetingLocation = async (chatRoomId: string) => {
   await clientSupabase.from('chatting_room').update({ meeting_location: null }).eq('chatting_room_id', chatRoomId);
+};
+
+export const updateMeetingLocation = async ({ chatRoomId, barName }: { chatRoomId: string; barName: string }) => {
+  const { data: DBdata, error } = await clientSupabase
+    .from('chatting_room')
+    .select('meeting_location')
+    .eq('chatting_room_id', chatRoomId)
+    .eq('meeting_location', barName);
+  if (error) console.error('fail to select meeting_location', error.message);
+  console.log('업데이트 함수 안 barName => ', barName);
+
+  if (DBdata && DBdata[0]) {
+    console.log('같은 게 있음!');
+    const { data, error } = await clientSupabase
+      .from('chatting_room')
+      .update({ meeting_location: null })
+      .eq('chatting_room_id', chatRoomId);
+    if (error) console.error('fail to update meetingLocation to null', error.message);
+    return data;
+  } else {
+    console.log('같은 게 없어서 바꿈!');
+    const { data, error } = await clientSupabase
+      .from('chatting_room')
+      .update({ meeting_location: barName })
+      .eq('chatting_room_id', chatRoomId);
+    if (error) console.error('fail to update meetingLocation to new', error.message);
+    return data;
+  }
 };

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -19,7 +19,6 @@ type chatState = {
   setSearchMode: () => void;
   setImgs: (imgs: File[]) => void;
   setOnlineUsers: (onlineUsers: string[]) => void;
-  // setSelectedMeetingTime: (value: React.SetStateAction<Date | null>) => void
 };
 
 export const chatStore = create<chatState>()((set) => ({
@@ -40,5 +39,4 @@ export const chatStore = create<chatState>()((set) => ({
   setSearchMode: () => set((state) => ({ searchMode: !state.searchMode })),
   setImgs: (imgs) => set({ imgs }),
   setOnlineUsers: (onlineUsers) => set({ onlineUsers })
-  // setSelectedMeetingTime:
 }));

--- a/src/store/sideBarStore.ts
+++ b/src/store/sideBarStore.ts
@@ -2,10 +2,14 @@ import { create } from 'zustand';
 
 type sideBarState = {
   isSidebarOpen: boolean;
+  // selectedMeetingLocation: string;
   setIsSidebarOpen: (isSidebarOpen: boolean) => void;
+  // setSelectedMeetingLocation: (barname: string) => void;
 };
 
 export const sideBarStore = create<sideBarState>()((set) => ({
   isSidebarOpen: true,
+  // selectedMeetingLocation: '',
   setIsSidebarOpen: (isSidebarOpen) => set({ isSidebarOpen })
+  // setSelectedMeetingLocation: (barname: string) => set({ selectedMeetingLocation: barname })
 }));

--- a/src/store/sideBarStore.ts
+++ b/src/store/sideBarStore.ts
@@ -2,14 +2,10 @@ import { create } from 'zustand';
 
 type sideBarState = {
   isSidebarOpen: boolean;
-  // selectedMeetingLocation: string;
   setIsSidebarOpen: (isSidebarOpen: boolean) => void;
-  // setSelectedMeetingLocation: (barname: string) => void;
 };
 
 export const sideBarStore = create<sideBarState>()((set) => ({
   isSidebarOpen: true,
-  // selectedMeetingLocation: '',
   setIsSidebarOpen: (isSidebarOpen) => set({ isSidebarOpen })
-  // setSelectedMeetingLocation: (barname: string) => set({ selectedMeetingLocation: barname })
 }));


### PR DESCRIPTION
### 📌 관련 이슈
#218 

### Task TODOLIST

- [x] 방장이 정한 미팅 시간과 날짜 실시간으로 채팅방에 참여 중인 사람들이 볼 수 있도록 Realtime 도입
- [x] initChat.tsx 단에서 chattingRoom이 UPDATE 될 때마다 query로 가져오던 채팅방 정보 구독하여, 리더가 아닌 사람들만queryClient.invalidateQueries()
- [x] 미팅 장소 변경하는 mutation 함수 -> clear과 update 로직 하나의 함수로 병합

### ✨ 개발 내용

**initChat.tsx 단에서 chattingRoom이 UPDATE 될 때마다 query로 가져오던 채팅방 정보 구독하여, 리더가 아닌 사람들만queryClient.invalidateQueries()**

```
 useEffect(() => {
    // 채팅방 isActive 상태 구독
    const channel = clientSupabase
      .channel(`${chatRoomId}_chatting_room_table`)
      .on(
        'postgres_changes',
        { event: 'UPDATE', schema: 'public', table: 'chatting_room', filter: `chatting_room_id=eq.${chatRoomId}` },
        (payload) => {
          setChatState((payload.new as chatRoomPayloadType).isActive);
          if (user?.id !== room?.leader_id) {
            queryClient.invalidateQueries({
              queryKey: [CHATDATA_QUERY_KEY]
            });
          }
        }
      )
      .subscribe();
    return () => {
      clientSupabase.removeChannel(channel);
    };
  }, [chatRoomId, setChatState]);
```

### 🚨TroubleShotting && 📸 스크린샷(선택)

리얼타임... 됐다가 안됐다가... 어떤 사람 컴퓨터에서는 됐다가... 내 컴에서는 안됐다가...
mutationFn에서 onSuccess가 실행되려면 mutationFunction에서 return 값을 반환해야 한다.
![image](https://github.com/Team-MeetGo/MeetGO/assets/154481757/43a5d2d7-2a74-4ef8-b016-8476d8dfb97c)

